### PR TITLE
fix. settings when val is false, null or empty string

### DIFF
--- a/termhelper.js
+++ b/termhelper.js
@@ -45,7 +45,7 @@
         if (!section || section === null || section === '') { s = 'settings'; }
         	
         if (!val && key === 'prompt') { val = ''; }
-        if (val) {
+        if (val !== undefined) {
           if (s === 'locale') {
             locale[key] = val;
           } else {


### PR DESCRIPTION
This fixes issue#1.

The problem was to set an false value (false, null, 0 or '') to the settings.

For example those lines:

```
term.set('settings', "prompt", '');
term.set('settings', 'appendEndChar', false);
term.set('settings', "echoKeys", false);
```
